### PR TITLE
UnitTestModel名をUnitModelに変更の対応

### DIFF
--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Unit extends Model
+{
+    use HasFactory;
+    protected $table = 'units';
+}

--- a/resources/views/unit_test.blade.php
+++ b/resources/views/unit_test.blade.php
@@ -7,8 +7,8 @@
     </div>
 </header>
 <div class="button text-center">
-    @foreach($UnitTest as $UnitTest)
-    <a href=""><button type="button" class="btn btn-success" style="width: 90%; height:150px; margin-top:20px; border-radius:20px">{{$UnitTest->name}}</button></a>
+    @foreach($UnitTest as $Unit)
+    <a href=""><button type="button" class="btn btn-success" style="width: 90%; height:150px; margin-top:20px; border-radius:20px">{{$Unit->name}}</button></a>
     @endforeach
 </div>
 @endsection


### PR DESCRIPTION
UnitTestModel名をUnitModelに変更の対応
テーブル名をunits_tableに変更し、わかりにくかった為。