### PR TITLE
問題の解答を正誤判定する機能の対応

### DIFF
--- a/app/Http/Controllers/ResultController.php
+++ b/app/Http/Controllers/ResultController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ReferenceBook;
+use App\Models\UnitTest;
+use Illuminate\Http\Request;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class ResultController extends Controller
+{
+    public function result(Request $request){
+        $posts = $request->all();
+        dd($posts);
+        return view('result');
+     }
+}

--- a/app/Http/Controllers/ResultController.php
+++ b/app/Http/Controllers/ResultController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Issue;
+use App\Models\IssueResult;
 use App\Models\ReferenceBook;
 use App\Models\UnitTest;
 use Illuminate\Http\Request;
@@ -11,8 +13,18 @@ use Illuminate\Support\Facades\DB;
 class ResultController extends Controller
 {
     public function result(Request $request){
+        $issue = new Issue;
         $posts = $request->all();
-        dd($posts);
+        $issues = $issue->get_all_issue();
+
+        foreach( $issues as $index => $issue){
+            $correct =  $issue->anser === $posts[$index+1];
+            if($correct){
+            IssueResult::create(['user_id' => 1, 'unit_id' => 1, 'issue_id' => 1, 'correct'=> true]);
+            }
+            IssueResult::create(['user_id' => 1, 'unit_id' => 1, 'issue_id' => 1,'correct'=> false]);
+            };
+            dd($issues);
         return view('result');
      }
 }

--- a/resources/views/issue.blade.php
+++ b/resources/views/issue.blade.php
@@ -1,8 +1,12 @@
 @extends('layouts.auth')
 
 @section('content')
-@foreach($Issue as $TestIssue)
-<p>{{$TestIssue->problem_statement}}</p>
-<a href="#"><button type="button" class="btn btn-success" style="width: 90%; height:150px; margin-top:20px; border-radius:20px">次へ</button></a>
-@endforeach
+<form class="issue-box pt-3" action="{{ route('result') }}" method="POST">
+    @csrf
+    @foreach($Issue as $Issue)
+    <p>{{$Issue->problem}}</p>
+    <input class="form-control mb-3" name="anser" type="text" placeholder="解答を入力" aria-label="default input example">
+    @endforeach
+    <button type="submit" class="btn btn-success">解答</button>
+</form>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\ReferenceBookPracticeController;
 use App\Http\Controllers\UnitTestController;
 use App\Http\Controllers\UnitPracticeController;
 use App\Http\Controllers\IssueController;
+use App\Http\Controllers\ResultController;
 
 /*
 |--------------------------------------------------------------------------
@@ -38,3 +39,5 @@ Route::get('/reference_book_test', [ReferenceBookTestController::class, 'referen
 Route::get('/reference_book_practice', [ReferenceBookPracticeController::class, 'reference_practice']);
 Route::get('/unit_test/{reference_book_id}', [UnitTestController::class, 'unit_test']);
 Route::get('/unit_practice/{reference_book_id}', [UnitPracticeController::class, 'unit_practice']);
+Route::get('/issue', [IssueController::class, 'issue']);
+Route::post('/result', [ResultController::class, 'result'])->name('result');


### PR DESCRIPTION
【やりたい事】
①test_resultテーブルに問題の数だけデータを入れたい
②test_resultテーブルに入力していく値を固定ではなく、対応した値を入れていきたい
【現状】
①問題数は10問ですが、写真のようになぜかtest_resultテーブルに16行分データが入る（truefalseもごちゃごちゃで入ってきてしまっている。）
②分からず止まっている
【試したこと】
①ddで$correct、$issues、$postsなどを確認しましたがいずれも表示されるデータは10個
②1と入れているところに'$issue->id'などと入れてみるもidが見つかりませんというエラーが発生する

原因が分からず止まってしまっています、、