### PR TITLE
React書き換え　正誤判定機能作成の対応

### DIFF
--- a/app/Http/Controllers/ResultController.php
+++ b/app/Http/Controllers/ResultController.php
@@ -16,21 +16,17 @@ use Illuminate\Support\Facades\DB;
 class ResultController extends Controller
 {
     public function result(Request $request){
-        $result = Result::create(['unit_id' => $request->unit_id, 'user_id' => \Auth::id()]);
+        $result = Result::create(['unit_id' => $request->unit_id, 'user_id' => 1]);
         $issue = new Issue;
-        $posts = $request->all();
-        $issues = $issue->select()
-                    ->join('unit_issues', 'unit_issues.issue_id', '=', 'issues.id')
-                    ->where('unit_id', $request->unit_id)
-                    ->whereNull('issues.deleted_at')
-                    ->get();
 
-        foreach( $issues as $index => $issue){
-            $correct =  $issue->anser === $posts[$issue->id];
+        foreach( $request->answers as $index => $answer){
+            // return response()->json($issue->find($answer['issueId'])->anser);
+            $issueId = $answer['issueId'];
+            $correct =  $issue->find($issueId)->anser === $answer['answer'];
             if($correct == true){
-                IssueResult::create(['issue_id' => $issue->id, 'correct'=> true, 'result_id' => $result->id]);
+                IssueResult::create(['issue_id' => $issueId, 'correct'=> true, 'result_id' => $result->id]);
                 } else{
-                    IssueResult::create(['issue_id' => $issue->id,'correct'=> false, 'result_id' => $result->id]);
+                    IssueResult::create(['issue_id' => $issueId,'correct'=> false, 'result_id' => $result->id]);
                 }
             };
 
@@ -49,14 +45,14 @@ class ResultController extends Controller
                             ->where('result_id', $result->id)
                             ->where('correct', '=', 1)->count();
 
-        return response()->json(
-            [
-                "issueResult" => $issueResult,
-                "issueCount" => $issueCount,
-                "score" => $score
-                ],
-                200,[],
-                JSON_UNESCAPED_UNICODE //文字化け対策
-            );
+            return response()->json(
+                [
+                    "issueResult" => $issueResult,
+                    "issueCount" => $issueCount,
+                    "score" => $score
+                    ],
+                    200,[],
+                    JSON_UNESCAPED_UNICODE //文字化け対策
+                );
      }
 }

--- a/app/Http/Controllers/ResultTestController.php
+++ b/app/Http/Controllers/ResultTestController.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\DB;
 class ResultTestController extends Controller
 {
     public function result_test(Request $request){
-        $result = Result::create(['unit_id' => $request->unit_id, 'user_id' => \Auth::id()]);
+        $result = Result::create(['unit_id' => $request->unit_id, 'user_id' => 1]);
         $issue = new Issue;
         $posts = $request->except(['_token', 'unit_id']);
         $keys = array_keys($posts);
@@ -25,12 +25,14 @@ class ResultTestController extends Controller
             return $issue->find($posts);
            }, $keys);
 
-        foreach( $issues as $index => $issue){
-            $correct =  $issue->anser === $posts[$issue->id];
+           foreach( $request->answers as $index => $answer){
+            // return response()->json($issue->find($answer['issueId'])->anser);
+            $issueId = $answer['issueId'];
+            $correct =  $issue->find($issueId)->anser === $answer['answer'];
             if($correct == true){
-                IssueResult::create(['issue_id' => $issue->id, 'correct'=> true, 'result_id' => $result->id]);
+                IssueResult::create(['issue_id' => $issueId, 'correct'=> true, 'result_id' => $result->id]);
                 } else{
-                    IssueResult::create(['issue_id' => $issue->id,'correct'=> false, 'result_id' => $result->id]);
+                    IssueResult::create(['issue_id' => $issueId,'correct'=> false, 'result_id' => $result->id]);
                 }
             };
 

--- a/frontend/src/components/AdminHome.jsx
+++ b/frontend/src/components/AdminHome.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom"
 import axios from "axios";
 
 

--- a/frontend/src/components/IssueList.jsx
+++ b/frontend/src/components/IssueList.jsx
@@ -1,32 +1,34 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useHistory } from "react-router-dom"
 import axios from "axios";
-import { Button, ChakraProvider, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import { Button, ChakraProvider, FormControl, FormLabel, Input, Box, Heading } from "@chakra-ui/react";
 import { HeaderUser } from "./organizm/HeaderUser";
 import styled from "styled-components";
 
 
     export const IssueList = () => {
         const { unit_id } = useParams();
+        const history = useHistory();
         const url = `http://localhost:8888/api/issue/${unit_id}`;
 
         const [issueList, setIssueList] = useState([])
 
         const [answers, setAnswers] = useState([])
 
+        const [resultList, setResultList] = useState([])
+
         const onChangeInput = (answer, issueId) => {
-            console.log('answers', answers)
-            // console.log('answer', answer)
-            // console.log('issueId', issueId)
         setAnswers([{issueId, answer}, ...answers.filter((a) => a.issueId !== issueId )] );
           }
 
-          const history = useHistory();
+        const onClickHome = async () => {
+            history.push('/');
+        }
 
         const onClickAdd = async () => {
-            console.log(answers);
-            // history.push('/result');
-            await axios.post(`http://localhost:8888/api/result`,{answers})
+            const res = await axios.post(`http://localhost:8888/api/result`,{answers, unit_id});
+            console.log(res);
+            setResultList(res.data.issueResult);
         }
 
         useEffect(() => {
@@ -39,8 +41,7 @@ import styled from "styled-components";
                   res.data.unitIssue.map((issue) => {
                     return {
                       issueId: issue.id,
-                      answer: null,
-                      unit_id: unit_id
+                      answer: null
                     }
                   })
                 )
@@ -54,20 +55,30 @@ import styled from "styled-components";
         <ChakraProvider>
             <HeaderUser />
             <SContainer>
-                <>
+                <Heading size='md' pt={5}>（）の中に入るものを解答してください。</Heading>
                 <FormControl>
                 {issueList.map((s) => {
             return (
-                <>
-                    <FormLabel>{s.problem}</FormLabel>
-                    <Input onChange={(e) => onChangeInput(e.target.value, s.id)} type='text' focusBorderColor='lime' placeholder='解答を入力してください' bg='whiteAlpha.800' my={2} width='99%' />
-                </>
+                <Box key={s.id}>
+                    <FormLabel pt={10}>{s.problem}</FormLabel>
+                    <Input onChange={(e) => onChangeInput(e.target.value, s.id)} type='text' focusBorderColor='lime' placeholder='解答を入力してください' bg='whiteAlpha.800' my={2} width='99%' autoComplete="off"/>
+                    <Box color='red'>
+                        {resultList.length > 0 && resultList.find(r => r.issue_id === s.id)?.commentary}
+                    </Box>
+                </Box>
                     )})}
+                    {
+                    resultList.length > 0 ? (
+                    <Button mt={4} colorScheme="teal" onClick={onClickHome} type="submit">
+                        HOMEへ
+                    </Button>
+                    ) : (
                     <Button mt={4} colorScheme="teal" onClick={onClickAdd} type="submit">
                         解答する
                     </Button>
+                    )
+                    }
                 </FormControl>
-                </>
             </SContainer>
         </ChakraProvider>
         )

--- a/frontend/src/components/IssueList.jsx
+++ b/frontend/src/components/IssueList.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom"
+import { useParams, useHistory } from "react-router-dom"
 import axios from "axios";
 import { Button, ChakraProvider, FormControl, FormLabel, Input } from "@chakra-ui/react";
 import { HeaderUser } from "./organizm/HeaderUser";
@@ -9,22 +9,24 @@ import styled from "styled-components";
     export const IssueList = () => {
         const { unit_id } = useParams();
         const url = `http://localhost:8888/api/issue/${unit_id}`;
+
         const [issueList, setIssueList] = useState([])
 
         const [answers, setAnswers] = useState([])
 
         const onChangeInput = (answer, issueId) => {
             console.log('answers', answers)
-            console.log('answer', answer)
-            console.log('issueId', issueId)
-            console.log('answers', answers)
+            // console.log('answer', answer)
+            // console.log('issueId', issueId)
         setAnswers([{issueId, answer}, ...answers.filter((a) => a.issueId !== issueId )] );
           }
 
+          const history = useHistory();
+
         const onClickAdd = async () => {
             console.log(answers);
-            // const res = await axios.post(`http://localhost:8888/api/result`,{answers})
-
+            // history.push('/result');
+            await axios.post(`http://localhost:8888/api/result`,{answers})
         }
 
         useEffect(() => {
@@ -32,12 +34,13 @@ import styled from "styled-components";
             try {
                 const res = await axios.get(url)
                 setIssueList(res.data.unitIssue)
-                console.log("res",res)
+                // console.log("res",res)
                 setAnswers(
                   res.data.unitIssue.map((issue) => {
                     return {
                       issueId: issue.id,
                       answer: null,
+                      unit_id: unit_id
                     }
                   })
                 )

--- a/frontend/src/components/IssueTestList.jsx
+++ b/frontend/src/components/IssueTestList.jsx
@@ -1,48 +1,84 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom"
+import { useParams, useHistory } from "react-router-dom"
 import axios from "axios";
-import { Button, ChakraProvider, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import { Button, ChakraProvider, FormControl, FormLabel, Input, Heading, Box } from "@chakra-ui/react";
 import { HeaderUser } from "./organizm/HeaderUser";
 import styled from "styled-components";
 
 
-    export const IssueTestList = () => {
-        const { unit_id } = useParams();
-        const url = `http://localhost:8888/api/issue_test/${unit_id}`;
-        const [issueTestList, setIssueTestList] = useState([])
-        useEffect(()=>{
-            (async ()=>{
-            try{
-                const res = await axios.get(url);
-            console.log(res.data.unitIssue);
-            setIssueTestList(res.data.unitIssue)
-                return;
-            }catch (e){
-                return e;
-            }
-            })();
-        },[]);
-        console.log("issueTestList",issueTestList);
+export const IssueTestList = () => {
+    const { unit_id } = useParams();
+    const history = useHistory();
+    const url = `http://localhost:8888/api/issue_test/${unit_id}`;
+
+    const [issueList, setIssueList] = useState([])
+
+    const [answers, setAnswers] = useState([])
+
+    const [resultList, setResultList] = useState([])
+
+    const onChangeInput = (answer, issueId) => {
+    setAnswers([{issueId, answer}, ...answers.filter((a) => a.issueId !== issueId )] );
+      }
+
+    const onClickHome = async () => {
+        history.push('/');
+    }
+
+    const onClickAdd = async () => {
+        const res = await axios.post(`http://localhost:8888/api/result_test`,{answers, unit_id});
+        console.log(res);
+        setResultList(res.data.issueResult);
+    }
+
+    useEffect(() => {
+        ;(async () => {
+        try {
+            const res = await axios.get(url)
+            setIssueList(res.data.unitIssue)
+            // console.log("res",res)
+            setAnswers(
+              res.data.unitIssue.map((issue) => {
+                return {
+                  issueId: issue.id,
+                  answer: null
+                }
+              })
+            )
+          } catch (e) {
+            return e
+          }
+        })()
+      }, [])
 
     return  (
         <ChakraProvider>
             <HeaderUser />
             <SContainer>
-                <>
+                <Heading size='md' pt={5}>（）の中に入るものを解答してください。</Heading>
                 <FormControl>
-                {issueTestList.map((s) => {
+                {issueList.map((s) => {
             return (
-                <>
-                    <FormLabel>{s.problem}</FormLabel>
-                    <Input type='text' focusBorderColor='lime' placeholder='解答を入力してください' bg='whiteAlpha.800' my={2} width='99%' />
-                </>
+                <Box key={s.id}>
+                    <FormLabel pt={10}>{s.problem}</FormLabel>
+                    <Input onChange={(e) => onChangeInput(e.target.value, s.id)} type='text' focusBorderColor='lime' placeholder='解答を入力してください' bg='whiteAlpha.800' my={2} width='99%' autoComplete="off"/>
+                    <Box color='red'>
+                        {resultList.length > 0 && resultList.find(r => r.issue_id === s.id)?.commentary}
+                    </Box>
+                </Box>
                     )})}
-                    {/* <Input type="hidden" value={value}/> */}
-                    <Button mt={4} colorScheme="teal">
-                        Submit
+                    {
+                    resultList.length > 0 ? (
+                    <Button mt={4} colorScheme="teal" onClick={onClickHome} type="submit">
+                        HOMEへ
                     </Button>
-                    </FormControl>
-                </>
+                    ) : (
+                    <Button mt={4} colorScheme="teal" onClick={onClickAdd} type="submit">
+                        解答する
+                    </Button>
+                    )
+                    }
+                </FormControl>
             </SContainer>
         </ChakraProvider>
         )

--- a/frontend/src/components/Result.jsx
+++ b/frontend/src/components/Result.jsx
@@ -3,7 +3,7 @@ import axios from "axios";
 
 
     export const Result = () => {
-        const url = "http://localhost:8888/api/result";
+        const url = `http://localhost:8888/api/result`;
         const [result, setResult] = useState([])
         useEffect(()=>{
             (async ()=>{


### PR DESCRIPTION
【やりたいこと】
・写真1枚目のように、解答の結果（answers）と一緒にunit_idも渡したい

【現状】
・解答の結果（answers）のみをpostすると写真2枚目のようなエラーが発生し、Networkのmessageを見ると、
「message: "SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'unit_id' cannot be null (SQL: insert into `results` (`unit_id`, `user_id`, `updated_at`, `created_at`) values (?, ?, 2023-03-02 00:19:09, 2023-03-02 00:19:09))"」というエラーが発生する
・現状一旦return内でunit_idを持ってきている状態です

【試したこと】
・上記のエラーを調べると、unit_idが渡ってきていないですよというエラーだと分かった
・さらに、unit_idが渡ってきていないため、写真3枚目、ResultControllerの選択しているコードが動いていないことに気づいた（選択しているコードをコメントアウトすると、別のエラーが出たが、現状のエラーは消えた為）

・unit_idを、写真1枚目のような形でデータとして渡そうとしていますが、うまく渡せません。
　mapメソッドの外で「unit_id: unit_id」を書いてみても、そもそもデータの中にunit_idが入ってこない